### PR TITLE
Compute PDF features dynamically

### DIFF
--- a/biLSTM-pdf2xsl.py
+++ b/biLSTM-pdf2xsl.py
@@ -1,6 +1,5 @@
 import os
 import datetime
-import pickle
 import numpy as np
 
 # Use TensorFlow's bundled Keras implementation to avoid relying on the
@@ -30,8 +29,10 @@ from tensorflow.keras.models import Model, Sequential
 from tensorflow.keras.optimizers import RMSprop
 from tensorflow.keras.callbacks import ModelCheckpoint, TensorBoard
 
+from feature_utils import load_or_generate_features
+
 #set_session(session)
-features = pickle.load(open("featsV-1.pkl", "rb"))
+features = load_or_generate_features()
 print(len(features))
 tokenizer = Tokenizer(filters='', split=" ", lower=False)
 

--- a/feature_utils.py
+++ b/feature_utils.py
@@ -1,0 +1,72 @@
+import os
+import pickle
+from typing import List
+
+import numpy as np
+from PIL import Image
+
+from tensorflow.keras.applications.inception_resnet_v2 import (
+    InceptionResNetV2,
+    preprocess_input,
+)
+from tensorflow.keras.preprocessing.image import img_to_array
+
+try:
+    from pdf2image import convert_from_path
+except Exception:  # pragma: no cover - only executed when pdf2image missing
+    convert_from_path = None
+
+def load_or_generate_features(pdf_dir: str = "pdfs", cache_path: str = "featsV-1.pkl") -> np.ndarray:
+    """Return visual features for PDF training data.
+
+    If ``cache_path`` exists the features are loaded from that pickle file.
+    Otherwise the PDFs (or images) found in ``pdf_dir`` are converted to
+    299x299 RGB images, processed with :func:`preprocess_input`, and passed
+    through a pretrained :class:`InceptionResNetV2` network to obtain
+    ``8x8x1536`` feature maps.  The computed features are cached to
+    ``cache_path`` for future runs.
+
+    Parameters
+    ----------
+    pdf_dir:
+        Directory containing training PDFs or already-rendered page images.
+    cache_path:
+        File path used to cache the extracted features.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(N, 8, 8, 1536)`` where ``N`` is the number of
+        documents found in ``pdf_dir``.
+    """
+    if os.path.exists(cache_path):
+        with open(cache_path, "rb") as f:
+            return pickle.load(f)
+
+    if not os.path.isdir(pdf_dir):
+        raise FileNotFoundError(f"PDF directory '{pdf_dir}' not found")
+
+    images: List[np.ndarray] = []
+    for fname in sorted(os.listdir(pdf_dir)):
+        path = os.path.join(pdf_dir, fname)
+        if fname.lower().endswith(".pdf"):
+            if convert_from_path is None:
+                raise ImportError(
+                    "pdf2image is required to convert PDFs. Install it via 'pip install pdf2image'"
+                )
+            page = convert_from_path(path, dpi=200, first_page=1, last_page=1)[0]
+        else:
+            page = Image.open(path)
+        page = page.resize((299, 299)).convert("RGB")
+        images.append(img_to_array(page))
+
+    images = np.array(images)
+    images = preprocess_input(images)
+
+    model = InceptionResNetV2(include_top=False, weights="imagenet")
+    features = model.predict(images, batch_size=16, verbose=1)
+
+    with open(cache_path, "wb") as f:
+        pickle.dump(features, f)
+
+    return features

--- a/transformer_pdf2xsl.py
+++ b/transformer_pdf2xsl.py
@@ -1,0 +1,145 @@
+import os
+import datetime
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.preprocessing.text import Tokenizer
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+from tensorflow.keras.utils import to_categorical
+from tensorflow.keras import layers
+from tensorflow.keras.models import Model, Sequential
+from tensorflow.keras.callbacks import ModelCheckpoint, TensorBoard
+from tensorflow.keras.optimizers import RMSprop
+
+from feature_utils import load_or_generate_features
+
+# ================================================================
+# Data loading
+# ================================================================
+features = load_or_generate_features()
+tokenizer = Tokenizer(filters='', split=" ", lower=False)
+
+# Read XSL training data
+all_filenames = os.listdir('xsl/')
+all_filenames.sort()
+raw_xsl_code = [open('xsl/' + fname).read() for fname in all_filenames]
+
+# Fit tokenizer and encode sequences
+tokenizer.fit_on_texts(raw_xsl_code)
+vocab_size = len(tokenizer.word_index) + 1
+sequences = tokenizer.texts_to_sequences(raw_xsl_code)
+max_length = max(len(s) for s in sequences)
+
+# Prepare training pairs (image, partial sequence -> next word)
+raw_xsl_code, raw_sequence_data, image_data = [], [], []
+for img_no, seq in enumerate(sequences):
+    for i in range(1, len(seq)):
+        in_seq, out_seq = seq[:i], seq[i]
+        in_seq = pad_sequences([in_seq], maxlen=max_length)[0]
+        out_seq = to_categorical([out_seq], num_classes=vocab_size)[0]
+        image_data.append(features[img_no])
+        raw_xsl_code.append(in_seq[-200:])
+        raw_sequence_data.append(out_seq)
+
+raw_xsl_code = np.array(raw_xsl_code)
+raw_sequence_data = np.array(raw_sequence_data)
+image_data = np.array(image_data)
+
+# ================================================================
+# Model building blocks
+# ================================================================
+class TokenAndPositionEmbedding(layers.Layer):
+    """Embedding layer that adds positional encodings."""
+    def __init__(self, maxlen, vocab_size, embed_dim):
+        super().__init__()
+        self.token_emb = layers.Embedding(vocab_size, embed_dim)
+        self.pos_emb = layers.Embedding(maxlen, embed_dim)
+        self.maxlen = maxlen
+
+    def call(self, x):
+        positions = tf.range(start=0, limit=self.maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        x = self.token_emb(x)
+        return x + positions
+
+class TransformerBlock(layers.Layer):
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super().__init__()
+        self.att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.ffn = Sequential([
+            layers.Dense(ff_dim, activation="relu"),
+            layers.Dense(embed_dim),
+        ])
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
+
+    def call(self, inputs, training):
+        attn_output = self.att(inputs, inputs)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(inputs + attn_output)
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        return self.layernorm2(out1 + ffn_output)
+
+# ================================================================
+# Image encoder
+# ================================================================
+image_model = Sequential([
+    layers.Conv2D(16, (3, 3), padding='valid', activation='relu', input_shape=(8, 8, 1536,)),
+    layers.Conv2D(16, (3, 3), activation='relu', padding='same', strides=2),
+    layers.Conv2D(32, (3, 3), activation='relu', padding='same'),
+    layers.Conv2D(32, (3, 3), activation='relu', padding='same', strides=2),
+    layers.Conv2D(64, (3, 3), activation='relu', padding='same'),
+    layers.Conv2D(64, (3, 3), activation='relu', padding='same', strides=2),
+    layers.Conv2D(128, (3, 3), activation='relu', padding='same'),
+    layers.Flatten(),
+    layers.Dense(1024, activation='relu'),
+    layers.Dropout(0.3),
+    layers.Dense(1024, activation='relu'),
+    layers.Dropout(0.3),
+    layers.Dense(256, activation='relu'),
+    layers.RepeatVector(200),
+])
+
+visual_input = layers.Input(shape=(8, 8, 1536,))
+encoded_image = image_model(visual_input)
+
+# ================================================================
+# Transformer-based language model with cross attention
+# ================================================================
+embed_dim = 256
+num_heads = 8
+ff_dim = 512
+
+language_input = layers.Input(shape=(200,))
+x = TokenAndPositionEmbedding(200, vocab_size, embed_dim)(language_input)
+x = TransformerBlock(embed_dim, num_heads, ff_dim)(x)
+
+# Cross attention with image features
+cross_attn = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+x2 = cross_attn(x, encoded_image)
+x = layers.LayerNormalization(epsilon=1e-6)(x + x2)
+
+x = layers.GlobalAveragePooling1D()(x)
+outputs = layers.Dense(vocab_size, activation='softmax')(x)
+
+model = Model(inputs=[visual_input, language_input], outputs=outputs)
+optimizer = RMSprop(learning_rate=1e-4, clipvalue=1.0)
+model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=['accuracy'])
+
+os.makedirs("futureweights", exist_ok=True)
+filepath = "futureweights/transformer-{epoch:02d}-{loss:.4f}.hdf5"
+checkpoint = ModelCheckpoint(filepath, monitor='loss', verbose=1, save_best_only=True, mode='auto')
+
+log_dir = "tuber/" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + "/"
+tensorboard = TensorBoard(log_dir=log_dir, write_graph=True, update_freq='epoch')
+callbacks_list = [tensorboard, checkpoint]
+
+model.fit([image_data, raw_xsl_code], raw_sequence_data,
+          validation_split=0.33,
+          batch_size=128,
+          shuffle=False,
+          epochs=200,
+          callbacks=callbacks_list)
+

--- a/xsl_to_pdf_transformer.py
+++ b/xsl_to_pdf_transformer.py
@@ -1,0 +1,128 @@
+import glob
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.preprocessing.text import Tokenizer
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+from tensorflow.keras import layers, Model
+from tensorflow.keras.applications import ResNet50
+from tensorflow.keras.optimizers import Adam
+
+
+class TokenAndPositionEmbedding(layers.Layer):
+    """Embedding layer that adds positional encodings."""
+
+    def __init__(self, maxlen, vocab_size, embed_dim):
+        super().__init__()
+        self.token_emb = layers.Embedding(vocab_size, embed_dim)
+        self.pos_emb = layers.Embedding(maxlen, embed_dim)
+        self.maxlen = maxlen
+
+    def call(self, x):
+        positions = tf.range(start=0, limit=self.maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        x = self.token_emb(x)
+        return x + positions
+
+
+class TransformerBlock(layers.Layer):
+    """Basic Transformer block used by LayoutTransformer and similar models."""
+
+    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
+        super().__init__()
+        self.att = layers.MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim)
+        self.ffn = tf.keras.Sequential(
+            [layers.Dense(ff_dim, activation="relu"), layers.Dense(embed_dim)]
+        )
+        self.layernorm1 = layers.LayerNormalization(epsilon=1e-6)
+        self.layernorm2 = layers.LayerNormalization(epsilon=1e-6)
+        self.dropout1 = layers.Dropout(rate)
+        self.dropout2 = layers.Dropout(rate)
+
+    def call(self, inputs, training):
+        attn_output = self.att(inputs, inputs)
+        attn_output = self.dropout1(attn_output, training=training)
+        out1 = self.layernorm1(inputs + attn_output)
+        ffn_output = self.ffn(out1)
+        ffn_output = self.dropout2(ffn_output, training=training)
+        return self.layernorm2(out1 + ffn_output)
+
+
+def build_model(maxlen: int, vocab_size: int, pdf_len: int) -> Model:
+    """Create a style‑conditioned Transformer that emits raw PDF bytes.
+
+    The network encodes an XSL token sequence, fuses it with a CNN style
+    embedding of a reference PDF page, and directly decodes a sequence of
+    byte values (0‑255) representing the final PDF file.  No external
+    rendering libraries are used – the model's predictions are written
+    verbatim to disk.
+    """
+
+    # Encode XSL tokens
+    xsl_input = layers.Input(shape=(maxlen,), name="xsl_tokens")
+    x = TokenAndPositionEmbedding(maxlen, vocab_size, 256)(xsl_input)
+    x = TransformerBlock(256, 4, 512)(x)
+
+    # Encode style image using ResNet50 to capture document appearance
+    style_input = layers.Input(shape=(224, 224, 3), name="style_image")
+    base_cnn = ResNet50(include_top=False, weights="imagenet", pooling="avg")
+    base_cnn.trainable = False
+    style_feat = base_cnn(style_input)
+    style_feat = layers.Dense(256, activation="relu")(style_feat)
+    style_feat = layers.Reshape((1, 256))(style_feat)
+
+    # Cross‑attention to inject style context into the token sequence
+    attn = layers.MultiHeadAttention(num_heads=4, key_dim=256)
+    style_context = attn(query=x, value=style_feat, key=style_feat)
+
+    # Combine style context with token embeddings then decode bytes
+    combined = layers.Concatenate()([x, style_context])
+    combined = TransformerBlock(512, 8, 1024)(combined)
+    combined = layers.GlobalAveragePooling1D()(combined)
+    byte_logits = layers.Dense(pdf_len * 256)(combined)
+    byte_logits = layers.Reshape((pdf_len, 256))(byte_logits)
+    pdf_bytes = layers.Softmax(axis=-1, name="pdf_bytes")(byte_logits)
+
+    model = Model(inputs=[xsl_input, style_input], outputs=pdf_bytes)
+    model.compile(optimizer=Adam(1e-4),
+                  loss="sparse_categorical_crossentropy",
+                  metrics=["accuracy"])
+    return model
+
+
+def preds_to_pdf(pred_seq, pdf_path: str):
+    """Write model predictions directly to a PDF file.
+
+    ``pred_seq`` should be a sequence of probability distributions over
+    256 byte values produced by ``build_model``. The argmax byte is taken
+    at each position and written verbatim to ``pdf_path``.
+    """
+
+    byte_ids = tf.argmax(pred_seq, axis=-1)
+    byte_arr = tf.cast(byte_ids, tf.uint8).numpy().tobytes()
+    with open(pdf_path, "wb") as f:
+        f.write(byte_arr)
+
+
+
+if __name__ == "__main__":
+    # Example workflow operating on multiple XSL files
+    xsl_files = sorted(glob.glob("xsl/*.xsl"))
+
+    xsl_texts = [open(f).read() for f in xsl_files]
+    tokenizer = Tokenizer(filters="", split=" ", lower=False)
+    tokenizer.fit_on_texts(xsl_texts)
+    sequences = tokenizer.texts_to_sequences(xsl_texts)
+    maxlen = 200
+    sequences = pad_sequences(sequences, maxlen=maxlen)
+
+    pdf_len = 256  # length of PDF byte sequence to model
+    dummy_pdf = np.zeros((len(sequences), pdf_len), dtype="int32")
+    template = b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF"
+    dummy_pdf[:, : len(template)] = np.frombuffer(template, dtype=np.uint8)
+    dummy_images = np.zeros((len(sequences), 224, 224, 3), dtype="float32")
+
+    model = build_model(maxlen, len(tokenizer.word_index) + 1, pdf_len)
+    model.fit([sequences, dummy_images], dummy_pdf, epochs=1)
+
+    preds = model.predict([sequences, dummy_images])
+    preds_to_pdf(preds[0], "sample_output.pdf")


### PR DESCRIPTION
## Summary
- Remove fpdf usage and generate PDF output directly from predicted layout tokens using minimal PDF 1.4 syntax
- Transformer now emits raw PDF byte tokens; helper writes model predictions directly to PDF files without external libraries

## Testing
- `python -m py_compile feature_utils.py biLSTM-pdf2xsl.py transformer_pdf2xsl.py xsl_to_pdf_transformer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fc178878832aa954214c22bc2f97